### PR TITLE
Adding OpenAPI vendor extension documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The OpenAPI document is distributed as a single **bundle** that uses OpenAPI
 components for reuse and portability using JSON Schema references (`$ref`).
 It is available in both JSON (`openapi.json`) and YAML (`openapi.yaml`).
 
+## Extensions
+
+Any [OpenAPI extensions](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#specification-extensions) used will be documented in [extensions](extensions.md).
+
 ## Contributing
 
 Because this schema is used internally by Pinterest's API infrastructure, we

--- a/extensions.md
+++ b/extensions.md
@@ -1,0 +1,27 @@
+# OpenAPI Extensions
+
+This document describes the [OpenAPI extensions](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#specification-extensions) used in Pinterest's REST API OpenAPI descriptions.
+
+## `x-ratelimit-category`
+
+### Purpose
+
+Defines a functional category used for [rate limiting](https://developers.pinterest.com/docs/api/v5/#tag/Rate-limits).
+
+### Usage
+
+`x-ratelimit-category` should be applied to each operation. Operations that share a rate limit category will share rate limit quota.
+
+The value should be a string.
+
+#### Example usage
+
+```yml
+  /user_account:
+    get:
+      summary: Get user account
+      tags:
+      - user_account
+      operationId: user_account/get
+      x-ratelimit-category: basic_org_read
+```


### PR DESCRIPTION
New file in root, `extensions.md` and docs for our first extension `x-ratelimit-category`.