### PR TITLE
Add GH action to update postman collection

### DIFF
--- a/.github/scripts/backup-collection.js
+++ b/.github/scripts/backup-collection.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const fs = require('fs');
+
+async function backupCollection() {
+  try {
+    const url = 'https://api.getpostman.com/collections/' + process.env.COLLECTION_UID;
+    console.log('Backup URL:', url);
+    
+    console.log('Making backup request...');
+    const config = {
+      method: 'get',
+      url,
+      headers: {
+        'X-Api-Key': process.env.POSTMAN_API_KEY
+      }
+    };
+    console.log('Request config:', JSON.stringify({ ...config, headers: { 'X-Api-Key': '***' } }, null, 2));
+    
+    const response = await axios(config);
+    
+    const backupPath = './postman/backup/collection_' + process.env.TIMESTAMP + '.json';
+    fs.writeFileSync(backupPath, JSON.stringify(response.data, null, 2));
+    console.log('Backup created successfully');
+  } catch (error) {
+    console.error('Backup failed:', error.response?.data || error.message);
+    process.exit(1);
+  }
+}
+
+backupCollection();

--- a/.github/scripts/update-collection.js
+++ b/.github/scripts/update-collection.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+const fs = require('fs');
+
+async function updateCollection() {
+  try {
+    const url = 'https://api.getpostman.com/collections/' + process.env.COLLECTION_UID;
+    console.log('Update URL:', url);
+    
+    const collectionData = JSON.parse(fs.readFileSync('./postman/collection.json'));
+    const payload = { collection: collectionData };
+    
+    console.log('Making update request...');
+    const config = {
+      method: 'put',
+      url,
+      headers: {
+        'X-Api-Key': process.env.POSTMAN_API_KEY,
+        'Content-Type': 'application/json'
+      },
+      data: payload
+    };
+    
+    const response = await axios(config);
+    
+    console.log('Collection updated successfully');
+    console.log('Response:', JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    console.error('Update failed:', error.response?.data || error.message);
+    process.exit(1);
+  }
+}
+
+updateCollection();

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+name: Transform OpenAPI to Postman Collection
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'v5/openapi.yaml'
+      - 'v5/openapi.json'
+
+
+jobs:
+  sync-to-postman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: |
+          npm install -g openapi-to-postmanv2
+          npm install axios
+
+      - name: Backup Current Postman Collection
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
+          TIMESTAMP: $(date +%Y%m%d_%H%M%S)
+        run: |
+          mkdir -p ./postman/backup
+          node .github/scripts/backup-collection.js
+
+      - name: Upload Backup as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: postman-collection-backup
+          path: ./postman/backup/collection_*.json
+          retention-days: 90
+
+      - name: Convert OpenAPI to Postman Collection
+        run: |
+          openapi2postmanv2 \
+            -s ./v5/openapi.yaml \
+            -o ./postman/collection.json \
+            -p \
+            --pretty
+
+      - name: Update Postman Collection
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
+        run: node .github/scripts/update-collection.js


### PR DESCRIPTION
This commit adds GitHub Actions workflow to automatically sync v5 schema with Postman collection.

- Automatically converts OpenAPI specs to Postman collection
- Creates backups of existing Postman collections before updates
- Stores backups as GitHub Actions artifacts
- Updates Postman collection via Postman API
- Triggers on OpenAPI file changes or manual workflow dispatch